### PR TITLE
fix: issue deduplication inline bash with automated scripts

### DIFF
--- a/.github/workflows/daily-solution.yml
+++ b/.github/workflows/daily-solution.yml
@@ -12,35 +12,10 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
 
-            - name: Find Today's Lecture File
-              id: locate-file
-              run: |
-                  FILE_PATH=$(git log --diff-filter=A --name-only --format="" -- "**/ANALYSIS.md" | head -n 1)
-
-                  if [ -z "$FILE_PATH" ]; then
-                    echo "No ANALYSIS.md files found in the repository."
-                    echo "found=false" >> $GITHUB_OUTPUT
-                  else
-                    echo "Found latest file: $FILE_PATH"
-                    echo "found=true" >> $GITHUB_OUTPUT
-                    echo "filepath=$FILE_PATH" >> $GITHUB_OUTPUT
-                    DIR_CONTEXT=$(dirname "$FILE_PATH" | sed 's|^\./||')
-                    FIRST_HEX=$(grep -m 1 '^#' "$FILE_PATH" | sed 's/^#\s*//')
-                    TITLE="${FIRST_HEX:-Daily Lecture Summary} ($DIR_CONTEXT)"
-                    echo "title=$TITLE" >> $GITHUB_OUTPUT
-                  fi
-
-            - name: Create Issue with Summary
-              if: steps.locate-file.outputs.found == 'true'
+            - name: Create issues for new solutions
               env:
                   GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
               run: |
-                  cat "${{ steps.locate-file.outputs.filepath }}" >> "$GITHUB_STEP_SUMMARY"
-                  gh issue create \
-                    --title "${{ steps.locate-file.outputs.title }}" \
-                    --body-file "${{ steps.locate-file.outputs.filepath }}" \
-                    --label "daily-solution" \
-                    --label "dsa-lecture"
+                  chmod +x scripts/create-daily-issues.sh
+                  ./scripts/create-daily-issues.sh

--- a/.github/workflows/daily-solution.yml
+++ b/.github/workflows/daily-solution.yml
@@ -1,6 +1,9 @@
 name: Daily LeetCode Solution
 on:
     workflow_dispatch:
+    push:
+        branches: ['feat/45-refine-github-actions-workflow']
+
     schedule:
         - cron: '30 17 * * *'
 permissions:

--- a/.github/workflows/daily-solution.yml
+++ b/.github/workflows/daily-solution.yml
@@ -1,9 +1,6 @@
 name: Daily LeetCode Solution
 on:
     workflow_dispatch:
-    push:
-        branches: ['feat/45-refine-github-actions-workflow']
-
     schedule:
         - cron: '30 17 * * *'
 permissions:
@@ -15,6 +12,8 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
             - name: Create issues for new solutions
               env:

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -1,0 +1,34 @@
+name: Update Solution Count Badge
+on:
+    workflow_run:
+        workflows:
+            - Daily LeetCode Solution
+        types:
+            - completed
+    workflow_dispatch:
+permissions:
+    contents: write
+jobs:
+    update-badge:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+            - name: Generate badge and solutions index
+              run: |
+                  chmod +x scripts/update-badge.sh
+                  ./scripts/update-badge.sh "${{ github.repository }}" "main"
+
+            - name: Commit and push
+              run: |
+                  git config user.name  "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add .github/badges/solutions.json .github/badges/badge.json
+                  git diff --cached --quiet && echo "No changes to commit" && exit 0
+                  COUNT=$(jq '. | length' .github/badges/solutions.json)
+                  git commit -m "chore: update claude solution count to $COUNT"
+                  git pull --rebase origin main
+                  git push

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -26,7 +26,7 @@ jobs:
               run: |
                   git config user.name  "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git add .github/badges/solutions.json .github/badges/badge.json
+                  git add .github/badges/solutions.json
                   git diff --cached --quiet && echo "No changes to commit" && exit 0
                   COUNT=$(jq '. | length' .github/badges/solutions.json)
                   git commit -m "chore: update claude solution count to $COUNT"

--- a/README_template.md
+++ b/README_template.md
@@ -6,6 +6,7 @@
 
 [![Build README](https://github.com/Stewie-pixel/claude-with-leetcode/actions/workflows/build.yml/badge.svg)](https://github.com/Stewie-pixel/claude-with-leetcode/actions/workflows/build-readme.yml)
 [![Problems Solved](https://img.shields.io/badge/dynamic/json?label=Solved&query=length&url=https://raw.githubusercontent.com/Stewie-pixel/claude-with-leetcode/main/.problemSiteData.json&color=brightgreen&logo=leetcode)](https://github.com/Stewie-pixel/claude-with-leetcode)
+[![Claude Solved](https://img.shields.io/badge/dynamic/json?label=Solved&query=length&url=https://raw.githubusercontent.com/Stewie-pixel/claude-with-leetcode/main/.github/badges/solutions.json&color=orange&logo=claude)](https://github.com/Stewie-pixel/claude-with-leetcode)
 <language-badges />
 
 A little assistant from Claude to help you learn daily LeetCode problems organised by DSA topic and difficulty.

--- a/java/141-linked-list-cycle/ANALYSIS.md
+++ b/java/141-linked-list-cycle/ANALYSIS.md
@@ -1,0 +1,172 @@
+**GitHub Issue: Lecture – Fast & Slow Pointers (Linked List Cycle)**  
+
+---  
+
+# Fast & Slow Pointers  
+
+## Video Solution  
+
+For more details about **Linked List Cycle**, watch the walkthrough at [https://www.youtube.com/watch?v=gBTe7lFR3vc](https://www.youtube.com/watch?v=gBTe7lFR3vc).  
+
+## Concept  
+
+The fast‑and‑slow pointer technique (also called Floyd’s Tortoise and Hare) uses two pointers that traverse a sequence at different speeds. If there is a cycle, the faster pointer will eventually “lap” the slower one and they will meet. If there is no cycle, the fast pointer will reach the end (`null`).  
+
+*Real‑world analogy:* Imagine a running track where one runner jogs at 1 m/s and another sprints at 2 m/s. If the track is a loop, the sprinter will eventually catch up to the jogger. If the track is a straight line that ends, the sprinter will reach the finish line first.  
+
+## When to Use It  
+
+Use fast‑and‑slow pointers when you see:  
+
+- A linked list (or any sequence accessed via `next` pointers) and you need to detect a cycle.  
+- Problems asking for the start of a cycle, the length of a cycle, or determining if two linked lists intersect.  
+- Situations where you need O(1) extra space and can afford O(n) time.  
+
+## Template  
+
+```python
+# Fast & Slow Pointers template for cycle detection in a singly linked list
+def has_cycle(head):
+    # Edge case: empty list or single node without a self‑loop
+    if not head or not head.next:
+        return False
+
+    slow = head          # moves 1 step each iteration
+    fast = head          # moves 2 steps each iteration
+
+    while fast and fast.next:   # ensure we can advance fast two steps
+        slow = slow.next
+        fast = fast.next.next
+        if slow is fast:        # meeting point → cycle exists
+            return True
+
+    return False                # fast reached the end → no cycle
+```
+
+---
+
+## LeetCode Problem Walkthrough  
+
+### Problem: 141. Linked List Cycle  
+
+https://leetcode.com/problems/linked-list-cycle/  
+
+### Approach 1: Brute Force (Hash Set)  
+
+**Algorithm**  
+Traverse the list while storing each visited node in a hash set. If we encounter a node that is already in the set, a cycle exists. If we reach `null`, there is no cycle.  
+
+**Implementation**  
+
+```python
+def hasCycle(head):
+    seen = set()
+    cur = head
+    while cur:
+        if cur in seen:          # node visited before → cycle
+            return True
+        seen.add(cur)
+        cur = cur.next
+    return False
+```
+
+**Complexity Analysis**  
+
+- Time complexity: O(n) — each node is visited once.  
+- Space complexity: O(n) — we may store every node in the set.  
+
+### Approach 2: Marking Nodes (In‑Place Modification)  
+
+**Intuition**  
+If we are allowed to modify the list temporarily, we can mark visited nodes (e.g., by setting a special flag or overwriting `next` with a sentinel). When we encounter a marked node again, a cycle exists. This avoids extra space but changes the input structure.  
+
+**Algorithm**  
+Iterate through the list. For each node, if its `next` pointer is already a special marker (e.g., a dummy node), return `True`. Otherwise, temporarily replace `next` with the marker and move to the original next node (saved before overwriting).  
+
+**Implementation**  
+
+```python
+def hasCycle(head):
+    marker = ListNode(0)          # any node not part of the original list
+    cur = head
+    while cur:
+        if cur.next is marker:    # we have seen this node before
+            return True
+        nxt = cur.next            # save original next
+        cur.next = marker         # mark as visited
+        cur = nxt                 # proceed with original next
+    return False
+```
+
+**Complexity Analysis**  
+
+- Time complexity: O(n) — each node processed once.  
+- Space complexity: O(1) — only a constant number of extra pointers.  
+*Note:* This approach mutates the list; acceptable only if the caller allows it.  
+
+### Approach 3: Fast & Slow Pointers (Floyd’s Tortoise and Hare)  
+
+**Intuition**  
+By moving two pointers at different speeds, a cycle guarantees that the faster pointer will eventually lap the slower one. If there is no cycle, the fast pointer will hit the list’s end. This meets the O(1) space follow‑up requirement.  
+
+**Algorithm**  
+
+1. Handle trivial cases (empty list or single node).  
+2. Initialize `slow` and `fast` at the head.  
+3. While `fast` and `fast.next` are not null:  
+   - Advance `slow` by one step.  
+   - Advance `fast` by two steps.  
+   - If `slow` equals `fast`, a cycle exists → return `True`.  
+4. If the loop exits, no cycle → return `False`.  
+
+**Implementation**  
+
+```python
+def hasCycle(head):
+    if not head or not head.next:
+        return False
+
+    slow = head
+    fast = head
+
+    while fast and fast.next:
+        slow = slow.next          # 1 step
+        fast = fast.next.next     # 2 steps
+        if slow is fast:          # meeting point
+            return True
+
+    return False
+```
+
+**Complexity Analysis**  
+
+- Time complexity: O(n) — in the worst case, the fast pointer traverses the list twice.  
+- Space complexity: O(1) — only two pointers are used regardless of input size.  
+
+## Provide a Visual Demonstration  
+
+**Impact: HIGH** | **Category: explanation** | **Tags:** dry-run, trace, example  
+
+### Dry Run  
+
+Input: `head = [3,2,0,-4]`, cycle connects node at index 1 (value 2) to tail.  
+
+| Step | slow (node) | fast (node) | Action                              |
+|------|-------------|-------------|-------------------------------------|
+| 0    | 3           | 3           | Initialize both at head             |
+| 1    | 2           | 0           | slow → 2, fast → 0 (two steps)     |
+| 2    | 0           | 2           | slow → 0, fast → 2 (two steps)     |
+| 3    | -4          | -4          | slow → -4, fast → -4 (two steps) → **meeting** → cycle detected |
+
+Since `slow` and `fast` meet at node `-4`, we return `True`.  
+
+If the list were `[1]` with `pos = -1` (no cycle):  
+
+| Step | slow | fast | Action                              |
+|------|------|------|-------------------------------------|
+| 0    | 1    | 1    | Start                               |
+| 1    | (null) | (null) | fast.next is null → loop ends → return `False` |
+
+---  
+
+*End of lecture.*

--- a/java/141-linked-list-cycle/README.md
+++ b/java/141-linked-list-cycle/README.md
@@ -1,0 +1,49 @@
+<h2><a href="https://leetcode.com/problems/linked-list-cycle">Linked List Cycle</a></h2>
+
+<img src="https://img.shields.io/badge/Difficulty-Easy-brightgreen" alt="Difficulty: Easy"/>
+
+<hr />
+
+<p>Given <code>head</code>, the head of a linked list, determine if the linked list has a cycle in it.</p>
+
+<p>There is a cycle in a linked list if there is some node in the list that can be reached again by continuously following the&nbsp;<code>next</code>&nbsp;pointer. Internally, <code>pos</code>&nbsp;is used to denote the index of the node that&nbsp;tail&#39;s&nbsp;<code>next</code>&nbsp;pointer is connected to.&nbsp;<strong>Note that&nbsp;<code>pos</code>&nbsp;is not passed as a parameter</strong>.</p>
+
+<p>Return&nbsp;<code>true</code><em> if there is a cycle in the linked list</em>. Otherwise, return <code>false</code>.</p>
+
+<p>&nbsp;</p>
+<p><strong class="example">Example 1:</strong></p>
+<img alt="" src="https://assets.leetcode.com/uploads/2018/12/07/circularlinkedlist.png" style="width: 300px; height: 97px; margin-top: 8px; margin-bottom: 8px;" />
+<pre>
+<strong>Input:</strong> head = [3,2,0,-4], pos = 1
+<strong>Output:</strong> true
+<strong>Explanation:</strong> There is a cycle in the linked list, where the tail connects to the 1st node (0-indexed).
+</pre>
+
+<p><strong class="example">Example 2:</strong></p>
+<img alt="" src="https://assets.leetcode.com/uploads/2018/12/07/circularlinkedlist_test2.png" style="width: 141px; height: 74px;" />
+<pre>
+<strong>Input:</strong> head = [1,2], pos = 0
+<strong>Output:</strong> true
+<strong>Explanation:</strong> There is a cycle in the linked list, where the tail connects to the 0th node.
+</pre>
+
+<p><strong class="example">Example 3:</strong></p>
+<img alt="" src="https://assets.leetcode.com/uploads/2018/12/07/circularlinkedlist_test3.png" style="width: 45px; height: 45px;" />
+<pre>
+<strong>Input:</strong> head = [1], pos = -1
+<strong>Output:</strong> false
+<strong>Explanation:</strong> There is no cycle in the linked list.
+</pre>
+
+<p>&nbsp;</p>
+<p><strong>Constraints:</strong></p>
+
+<ul>
+	<li>The number of the nodes in the list is in the range <code>[0, 10<sup>4</sup>]</code>.</li>
+	<li><code>-10<sup>5</sup> &lt;= Node.val &lt;= 10<sup>5</sup></code></li>
+	<li><code>pos</code> is <code>-1</code> or a <strong>valid index</strong> in the linked-list.</li>
+</ul>
+
+<p>&nbsp;</p>
+<p><strong>Follow up:</strong> Can you solve it using <code>O(1)</code> (i.e. constant) memory?</p>
+

--- a/java/141-linked-list-cycle/linked-list-cycle.java
+++ b/java/141-linked-list-cycle/linked-list-cycle.java
@@ -1,0 +1,34 @@
+/**
+ * Definition for singly-linked list.
+ * class ListNode {
+ *     int val;
+ *     ListNode next;
+ *     ListNode(int x) {
+ *         val = x;
+ *         next = null;
+ *     }
+ * }
+ */
+public class Solution {
+
+    public boolean hasCycle(ListNode head) {
+        if (head == null || head.next == null) {
+            return false;
+        }
+
+        ListNode slowPointer = head;
+        ListNode fastPointer = head;
+
+        while (fastPointer.next != null && fastPointer.next.next != null) {
+            slowPointer = slowPointer.next;
+            fastPointer = fastPointer.next.next;
+
+            if (slowPointer == fastPointer) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+    // TC: O(n), SC: O(1);
+}

--- a/scripts/create-daily-issues.sh
+++ b/scripts/create-daily-issues.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# scripts/create-daily-issues.sh
+
+set -euo pipefail
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "Error: GH_TOKEN environment variable is required."
+  exit 1
+fi
+
+echo "Scanning for ANALYSIS.md files..."
+
+EXISTING_ISSUES=$(gh issue list --label "daily-solution" --json title --jq '.[].title' --limit 1000)
+
+declare -A SLUG_TO_FILE
+declare -A SLUG_TO_LANGS
+
+while IFS= read -r FILE_PATH; do
+  [ -z "$FILE_PATH" ] && continue
+
+  SLUG=$(dirname "$FILE_PATH" | xargs basename)
+
+  LANG=$(basename "$(dirname "$(dirname "$FILE_PATH")")")
+
+  if [ -z "${SLUG_TO_FILE[$SLUG]+x}" ]; then
+    SLUG_TO_FILE[$SLUG]="$FILE_PATH"
+  fi
+
+  SLUG_TO_LANGS[$SLUG]="${SLUG_TO_LANGS[$SLUG]:-}${SLUG_TO_LANGS[$SLUG]:+ }$LANG"
+
+done < <(find . -path "./.git" -prune -o -name "ANALYSIS.md" -print | sed 's|^\./||' | sort)
+
+ISSUE_COUNT=0
+BODY_FILE=$(mktemp)
+trap 'rm -f "$BODY_FILE"' EXIT
+
+for SLUG in "${!SLUG_TO_FILE[@]}"; do
+  REPRESENTATIVE="${SLUG_TO_FILE[$SLUG]}"
+  LANGS=$(echo "${SLUG_TO_LANGS[$SLUG]}" | tr ' ' '\n' | sort -u | grep -v '^$' | paste -sd ', ')
+
+  FIRST_HEADING=$(grep -m 1 '^#' "$REPRESENTATIVE" | sed 's/^#\s*//')
+  TITLE="${FIRST_HEADING:-$SLUG}"
+
+  if echo "$EXISTING_ISSUES" | grep -qF "$TITLE"; then
+    echo "Issue already exists, skipping: $TITLE"
+    continue
+  fi
+
+  {
+    echo "**Languages:** $LANGS"
+    echo ""
+    cat "$REPRESENTATIVE"
+  } > "$BODY_FILE"
+
+  gh issue create \
+    --title "$TITLE" \
+    --body-file "$BODY_FILE" \
+    --label "daily-solution" \
+    --label "dsa-lecture"
+
+  echo "Created issue: $TITLE [$LANGS]"
+  ISSUE_COUNT=$((ISSUE_COUNT + 1))
+done
+
+echo ""
+echo "Total issues created: $ISSUE_COUNT"

--- a/scripts/create-daily-issues.sh
+++ b/scripts/create-daily-issues.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# scripts/create-daily-issues.sh
 
 set -euo pipefail
 
@@ -8,9 +7,13 @@ if [ -z "${GH_TOKEN:-}" ]; then
   exit 1
 fi
 
-echo "Scanning for ANALYSIS.md files..."
+echo "Scanning for ANALYSIS.md files added in the last 24 hours..."
 
-EXISTING_ISSUES=$(gh issue list --label "daily-solution" --json title --jq '.[].title' --limit 1000)
+EXISTING_ISSUES=$(gh issue list \
+  --label "daily-solution" \
+  --json title \
+  --jq '.[].title' \
+  --limit 1000)
 
 declare -A SLUG_TO_FILE
 declare -A SLUG_TO_LANGS
@@ -18,8 +21,11 @@ declare -A SLUG_TO_LANGS
 while IFS= read -r FILE_PATH; do
   [ -z "$FILE_PATH" ] && continue
 
-  SLUG=$(dirname "$FILE_PATH" | xargs basename)
+  if [ ! -f "$FILE_PATH" ]; then
+    continue
+  fi
 
+  SLUG=$(basename "$(dirname "$FILE_PATH")")
   LANG=$(basename "$(dirname "$(dirname "$FILE_PATH")")")
 
   if [ -z "${SLUG_TO_FILE[$SLUG]+x}" ]; then
@@ -28,20 +34,40 @@ while IFS= read -r FILE_PATH; do
 
   SLUG_TO_LANGS[$SLUG]="${SLUG_TO_LANGS[$SLUG]:-}${SLUG_TO_LANGS[$SLUG]:+ }$LANG"
 
-done < <(find . -path "./.git" -prune -o -name "ANALYSIS.md" -print | sed 's|^\./||' | sort)
+done < <(
+  git log \
+    --since="24 hours ago" \
+    --name-only \
+    --diff-filter=A \
+    --pretty="" |
+  grep 'ANALYSIS.md$' |
+  sort -u
+)
+
+if [ ${#SLUG_TO_FILE[@]} -eq 0 ]; then
+  echo "No new ANALYSIS.md files found in the last 24 hours."
+  exit 0
+fi
 
 ISSUE_COUNT=0
 BODY_FILE=$(mktemp)
+
 trap 'rm -f "$BODY_FILE"' EXIT
 
 for SLUG in "${!SLUG_TO_FILE[@]}"; do
   REPRESENTATIVE="${SLUG_TO_FILE[$SLUG]}"
-  LANGS=$(echo "${SLUG_TO_LANGS[$SLUG]}" | tr ' ' '\n' | sort -u | grep -v '^$' | paste -sd ', ')
+
+  LANGS=$(echo "${SLUG_TO_LANGS[$SLUG]}" \
+    | tr ' ' '\n' \
+    | sort -u \
+    | grep -v '^$' \
+    | paste -sd ', ')
 
   FIRST_HEADING=$(grep -m 1 '^#' "$REPRESENTATIVE" | sed 's/^#\s*//')
+
   TITLE="${FIRST_HEADING:-$SLUG}"
 
-  if echo "$EXISTING_ISSUES" | grep -qF "$TITLE"; then
+  if echo "$EXISTING_ISSUES" | grep -Fxq "$TITLE"; then
     echo "Issue already exists, skipping: $TITLE"
     continue
   fi
@@ -59,6 +85,7 @@ for SLUG in "${!SLUG_TO_FILE[@]}"; do
     --label "dsa-lecture"
 
   echo "Created issue: $TITLE [$LANGS]"
+
   ISSUE_COUNT=$((ISSUE_COUNT + 1))
 done
 

--- a/scripts/update-badge.sh
+++ b/scripts/update-badge.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO="${1:-}"
+BRANCH="${2:-main}"
+
+if [ -z "$REPO" ]; then
+  echo "Error: repository argument is required."
+  echo "Usage: $0 <owner/repo> [branch]"
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required but not installed."
+  exit 1
+fi
+
+echo "Scanning for ANALYSIS.md files..."
+
+declare -A SEEN_SLUGS
+RAW_ENTRIES=()
+
+while IFS= read -r FILE_PATH; do
+  [ -z "$FILE_PATH" ] && continue
+
+  SLUG=$(echo "$FILE_PATH" | awk -F'/' '{print $(NF-1)}')
+
+  if [ -n "${SEEN_SLUGS[$SLUG]+x}" ]; then
+    continue
+  fi
+  SEEN_SLUGS[$SLUG]=1
+
+  TITLE=$(grep -m 1 '^#' "$FILE_PATH" 2>/dev/null | sed 's/^#\s*//')
+  TITLE="${TITLE:-$SLUG}"
+
+  FILE_URL="https://github.com/$REPO/blob/$BRANCH/$FILE_PATH"
+
+  ENTRY=$(jq -n \
+    --arg slug "$SLUG" \
+    --arg title "$TITLE" \
+    --arg url "$FILE_URL" \
+    '{slug: $slug, title: $title, url: $url}')
+
+  RAW_ENTRIES+=("$ENTRY")
+
+done < <(find . -path "./.git" -prune -o -name "ANALYSIS.md" -print | sed 's|^\./||' | sort)
+
+ENTRIES=$(printf '%s\n' "${RAW_ENTRIES[@]}" | jq -s '.')
+COUNT=$(echo "$ENTRIES" | jq '. | length')
+
+mkdir -p .github/badges
+
+echo "$ENTRIES" | jq '.' > .github/badges/solutions.json
+echo "Written: .github/badges/solutions.json ($COUNT entries)"
+
+cat > .github/badges/badge.json <<EOF
+{
+  "schemaVersion": 1,
+  "label": "LeetCode solutions",
+  "message": "$COUNT solved"
+}
+EOF
+echo "Written: .github/badges/badge.json"
+
+echo ""
+echo "Total unique problems: $COUNT"

--- a/scripts/update-badge.sh
+++ b/scripts/update-badge.sh
@@ -54,14 +54,5 @@ mkdir -p .github/badges
 echo "$ENTRIES" | jq '.' > .github/badges/solutions.json
 echo "Written: .github/badges/solutions.json ($COUNT entries)"
 
-cat > .github/badges/badge.json <<EOF
-{
-  "schemaVersion": 1,
-  "label": "LeetCode solutions",
-  "message": "$COUNT solved"
-}
-EOF
-echo "Written: .github/badges/badge.json"
-
 echo ""
 echo "Total unique problems: $COUNT"

--- a/skills/dsa-mentor.md
+++ b/skills/dsa-mentor.md
@@ -59,7 +59,7 @@ You are an expert DSA mentor helping a developer improve their Data Structure Al
 
 3. **Find a video solution** - The user will provide real YouTube search results from Serper in the prompt. Pick the most relevant direct `youtube.com/watch?v=...` URL from those results. Prefer NeetCode. If no NeetCode result is present, accept any reputable DSA channel. Never use a YouTube search results page URL. Never fabricate a URL. If no results were provided, omit the Video Solution section entirely.
 
-4. **Write a lecture** and save it as a Github issue using the structure below.
+4. **Write a lecture** using the structure below.
 
 > Note: `/topic` folder is the name of the topic aligned with the lecture (e.g. Two Sum belongs to `arrays-hashing`)
 

--- a/syncLeetcode.js
+++ b/syncLeetcode.js
@@ -310,22 +310,23 @@ async function run() {
             console.log(
                 `\nSuccessfully synced ${newProblemsSynced} solution(s).`,
             );
-
-            try {
-                console.log('\nRunning updateSiteData.js...');
-                execSync('node updateSiteData.js', { stdio: 'inherit' });
-
-                console.log('\nRunning updateTable.js...');
-                execSync('node updateTable.js', { stdio: 'inherit' });
-
-                console.log('\nREADME table rebuild completed successfully.');
-            } catch (err) {
-                console.error('\nFailed to run update scripts:', err.message);
-            }
         } else {
             console.log(
                 '\nNo new solutions found to sync. Everything is up to date.',
             );
+        }
+
+        try {
+            console.log('\nRunning updateSiteData.js...');
+            execSync('node updateSiteData.js', { stdio: 'inherit' });
+
+            console.log('\nRunning updateTable.js...');
+            execSync('node updateTable.js', { stdio: 'inherit' });
+
+            console.log('\nREADME table rebuild completed successfully.');
+        } catch (err) {
+            console.error('\nFailed to run update scripts:', err.message);
+            process.exit(1);
         }
     } catch (err) {
         console.error('\nExecution failed:', err.message);


### PR DESCRIPTION
- Move daily issue creation logic to scripts/create-daily-issues.sh
- Move badge update logic to scripts/update-badge.sh
- Remove git range logic from daily-solution.yml; scan full repo instead and skip problems with an existing daily-solution issue
- Add update-badge.yml triggered on workflow_run after daily-solution
- Fix syncLeetcode.js: move execSync outside newProblemsSynced guard