### PR TITLE
feat(rust): add 94/binary-tree-inorder-traversal

### DIFF
--- a/rust/94-binary-tree-inorder-traversal/README.md
+++ b/rust/94-binary-tree-inorder-traversal/README.md
@@ -1,0 +1,34 @@
+<h2><a href="https://leetcode.com/problems/binary-tree-inorder-traversal">94. Binary Tree Inorder Traversal</a></h2> <img src='https://img.shields.io/badge/Difficulty-Easy-brightgreen' alt='Difficulty: Easy' /><hr><p>Given the <code>root</code> of a binary tree, return <em>the inorder traversal of its nodes&#39; values</em>.</p>
+
+<p>&nbsp;</p>
+<p><strong class="example">Example 1:</strong></p>
+
+<pre>
+<strong>Input:</strong> root = [1,null,2,3]
+<strong>Output:</strong> [1,3,2]
+</pre>
+
+<p><strong class="example">Example 2:</strong></p>
+
+<pre>
+<strong>Input:</strong> root = []
+<strong>Output:</strong> []
+</pre>
+
+<p><strong class="example">Example 3:</strong></p>
+
+<pre>
+<strong>Input:</strong> root = [1]
+<strong>Output:</strong> [1]
+</pre>
+
+<p>&nbsp;</p>
+<p><strong>Constraints:</strong></p>
+
+<ul>
+	<li>The number of nodes in the tree is in the range <code>[0, 100]</code>.</li>
+	<li><code>-100 &lt;= Node.val &lt;= 100</code></li>
+</ul>
+
+<p>&nbsp;</p>
+<strong>Follow-up:&nbsp;</strong>Recursive solution is trivial, could you do it iteratively?

--- a/rust/94-binary-tree-inorder-traversal/binary-tree-inorder-traversal.rs
+++ b/rust/94-binary-tree-inorder-traversal/binary-tree-inorder-traversal.rs
@@ -1,0 +1,45 @@
+// Definition for a binary tree node.
+// #[derive(Debug, PartialEq, Eq)]
+// pub struct TreeNode {
+//   pub val: i32,
+//   pub left: Option<Rc<RefCell<TreeNode>>>,
+//   pub right: Option<Rc<RefCell<TreeNode>>>,
+// }
+// 
+// impl TreeNode {
+//   #[inline]
+//   pub fn new(val: i32) -> Self {
+//     TreeNode {
+//       val,
+//       left: None,
+//       right: None
+//     }
+//   }
+// }
+
+use std::rc::Rc;
+use std::cell::RefCell;
+
+pub struct Solution;
+
+impl Solution {
+    pub fn inorder_traversal(root: Option<Rc<RefCell<TreeNode>>>) -> Vec<i32> {
+        let mut result = Vec::new();
+        let mut stack = Vec::new();
+        let mut current = root;
+
+        while current.is_some() || !stack.is_empty() {
+            while let Some(node) = current {
+                stack.push(node.clone());
+                current = node.borrow().left.clone();
+            }
+            
+            if let Some(node) = stack.pop() {
+                result.push(node.borrow().val);
+                current = node.borrow().right.clone();
+            }
+        }
+
+        result
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds an iterative solution for LeetCode 94 (Binary Tree Inorder Traversal) in Rust. It provides a clean, non-recursive reference implementation for tree traversals.

## Details

The solution utilizes an explicit vector as a stack to safely navigate the tree's left branches without risking a stack overflow from deep recursion. It handles Rust's smart pointer types like `Rc` and `RefCell` to borrow and clone node references cleanly during the traversal process.

## Related Issues

Closes #94

## How to Validate

You can validate this change by running the solution against the LeetCode test suite for problem 94 to ensure all test cases pass successfully.

## Pre-Merge Checklist

- [x] Folder named correctly: `94-binary-tree-inorder-traversal`
- [x] Folder placed inside the correct language directory: `rust/94-binary-tree-inorder-traversal/`
- [x] Solution file named correctly: `binary-tree-inorder-traversal.rs`
- [x] `README.md` exists in the problem folder with the LeetCode HTML description
- [x] No `ANALYSIS.md` manually added (auto-generated by CI pipeline)
- [x] No debug print statements left in the solution
- [x] PR description is filled in with Summary, Related Issue, and How to Validate