### PR TITLE
feat(py): added solution for pascal's triangle in Python

### DIFF
--- a/python/118-pascals-triangle/README.md
+++ b/python/118-pascals-triangle/README.md
@@ -1,0 +1,20 @@
+<h2><a href="https://leetcode.com/problems/pascals-triangle">118. Search Insert Position</a></h2> <img src='https://img.shields.io/badge/Difficulty-Easy-brightgreen' alt='Difficulty: Easy' />
+<div class="HTMLContent_html__0OZLp" data-track-load="description_content"><p>Given an integer <code>numRows</code>, return the first numRows of <strong>Pascal's triangle</strong>.</p>
+
+<p>In <strong>Pascal's triangle</strong>, each number is the sum of the two numbers directly above it as shown:</p>
+<img alt="" style="height: 240px; width: 260px;" src="https://upload.wikimedia.org/wikipedia/commons/0/0d/PascalTriangleAnimated2.gif">
+<p>&nbsp;</p>
+<p><strong class="example">Example 1:</strong></p>
+<pre><strong>Input:</strong> numRows = 5
+<strong>Output:</strong> [[1],[1,1],[1,2,1],[1,3,3,1],[1,4,6,4,1]]
+</pre><p><strong class="example">Example 2:</strong></p>
+<pre><strong>Input:</strong> numRows = 1
+<strong>Output:</strong> [[1]]
+</pre>
+<p>&nbsp;</p>
+<p><strong>Constraints:</strong></p>
+
+<ul>
+	<li><code>1 &lt;= numRows &lt;= 30</code></li>
+</ul>
+</div>

--- a/python/118-pascals-triangle/pascals-triangle.py
+++ b/python/118-pascals-triangle/pascals-triangle.py
@@ -20,3 +20,4 @@ class Solution:
 
                 res[i] = tmp
         return res
+    

--- a/python/118-pascals-triangle/pascals-triangle.py
+++ b/python/118-pascals-triangle/pascals-triangle.py
@@ -1,0 +1,22 @@
+class Solution:
+    def generate(self, numRows):
+        """
+        :type numRows: int
+        :rtype: List[List[int]]
+        """
+        res = [[] for _ in range(numRows)]
+        for i in range(numRows):
+            if i == 0:
+                res[0] = [1]
+                continue
+            elif i == 1:
+                res[1] = [1,1]
+                continue
+            else:
+                tmp = [0] * (i+1)
+                tmp[0], tmp[-1] = 1,1
+                for j in range(1,i):
+                    tmp[j] = res[i-1][j] + res[i-1][j-1]
+
+                res[i] = tmp
+        return res


### PR DESCRIPTION
## Summary

This branch added solution for **118. Pascal's Triangle** in Python programming language

## Details

I will initialize a list named `res`, which contains empty lists with the same length as `numRows`.

During the iteration, if `i` is `0` or `1`, I will directly update the corresponding element in `res` to `[1]` and `[1, 1]`.

From `i = 2` onward, I will initialize a temporary list named `tmp`, filled with `0`s and having a length of `i + 1`. Then, I will set the first and last elements of `tmp` to `1`.

After that, I will iterate through the middle positions of the current row, with `j` running from `1` to `i - 1`. Each element at index `j` is calculated using the formula:

`tmp[j] = res[i - 1][j] + res[i - 1][j - 1]`

Finally, I assign `tmp` to `res[i]`.


## Related Issues

None

## How to Validate

Use all test cases provided in Leetcode to ensure that all test cases are corrected

## Pre-Merge Checklist

- [x] Folder named correctly: `118-pascals-triangle`
- [x] Folder placed inside the correct language directory e.g. `python/118-pascals-triangle/`
- [x] Solution file named correctly: `pascals-triangle.py`
- [x] `README.md` exists in the problem folder with the LeetCode HTML description
- [x] No `ANALYSIS.md` manually added (auto-generated by CI pipeline)
- [x] No debug print statements left in the solution
- [x] PR description is filled in with Summary, Related Issue, and How to Validate
