### PR TITLE
feat(rust): add new solution for problem 6

### DIFF
--- a/rust/6-zigzag-conversion/README.md
+++ b/rust/6-zigzag-conversion/README.md
@@ -1,0 +1,52 @@
+<h2><a href="https://leetcode.com/problems/zigzag-conversion">Zigzag Conversion</a></h2> <img src='https://img.shields.io/badge/Difficulty-Medium-orange' alt='Difficulty: Medium' /><hr><p>The string <code>&quot;PAYPALISHIRING&quot;</code> is written in a zigzag pattern on a given number of rows like this: (you may want to display this pattern in a fixed font for better legibility)</p>
+
+<pre>
+P   A   H   N
+A P L S I I G
+Y   I   R
+</pre>
+
+<p>And then read line by line: <code>&quot;PAHNAPLSIIGYIR&quot;</code></p>
+
+<p>Write the code that will take a string and make this conversion given a number of rows:</p>
+
+<pre>
+string convert(string s, int numRows);
+</pre>
+
+<p>&nbsp;</p>
+<p><strong class="example">Example 1:</strong></p>
+
+<pre>
+<strong>Input:</strong> s = &quot;PAYPALISHIRING&quot;, numRows = 3
+<strong>Output:</strong> &quot;PAHNAPLSIIGYIR&quot;
+</pre>
+
+<p><strong class="example">Example 2:</strong></p>
+
+<pre>
+<strong>Input:</strong> s = &quot;PAYPALISHIRING&quot;, numRows = 4
+<strong>Output:</strong> &quot;PINALSIGYAHRPI&quot;
+<strong>Explanation:</strong>
+P     I    N
+A   L S  I G
+Y A   H R
+P     I
+</pre>
+
+<p><strong class="example">Example 3:</strong></p>
+
+<pre>
+<strong>Input:</strong> s = &quot;A&quot;, numRows = 1
+<strong>Output:</strong> &quot;A&quot;
+</pre>
+
+<p>&nbsp;</p>
+<p><strong>Constraints:</strong></p>
+
+<ul>
+	<li><code>1 &lt;= s.length &lt;= 1000</code></li>
+	<li><code>s</code> consists of English letters (lower-case and upper-case), <code>&#39;,&#39;</code> and <code>&#39;.&#39;</code>.</li>
+	<li><code>1 &lt;= numRows &lt;= 1000</code></li>
+</ul>
+

--- a/rust/6-zigzag-conversion/zigzag-conversion.rs
+++ b/rust/6-zigzag-conversion/zigzag-conversion.rs
@@ -1,0 +1,29 @@
+impl Solution {
+    pub fn convert(s: String, num_rows: i32) -> String {
+        let num_rows = num_rows as usize;
+
+        if num_rows <= 1 || s.len() <= num_rows {
+            return s;
+        }
+
+        let mut rows: Vec<String> = vec![String::new(); num_rows];
+        let mut current_row: usize = 0;
+        let mut going_down = false;
+
+        for c in s.chars() {
+            rows[current_row].push(c);
+
+            if current_row == 0 || current_row == num_rows - 1 {
+                going_down = !going_down;
+            }
+
+            current_row = if going_down {
+                current_row + 1
+            } else {
+                current_row - 1
+            };
+        }
+
+        rows.concat()
+    }
+}


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and urgency. -->
Adds a Rust solution for LeetCode #6 (Zigzag Conversion)

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
Implements `convert(s: String, num_rows: i32) -> String` using the standard row-bounce technique: walk the input string once, appending each character to a `Vec<String>` row buffer indexed by `current_row`, flipping direction (`going_down`) whenever the top or bottom row is hit, then concatenating all rows at the end.

- Time complexity: O(n), single pass over the input
- Space complexity: O(n), one `Vec<String>` sized to the input plus row overhead
- Early return for `num_rows <= 1` or `s.len() <= num_rows`, where zigzagging has no effect on the output

This file is new (not modifying an existing solution), so every line in the diff is a pure addition — useful as a baseline case to confirm `buildValidDiffLines`'s new `added` set covers the whole file and the reviewer doesn't log any "anchored to context line" warnings that shouldn't fire here.

The `README.md` reproduces the LeetCode HTML description with a `<strong>Constraints:</strong><ul><li>...</li></ul>` block in the same shape as the real LeetCode-exported READMEs, so `extractConstraints` has real constraint text (`1 <= s.length <= 1000`, `1 <= numRows <= 1000`) to extract and feed into the DSA rubric's complexity check.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include screenshots,
expected results, and edge cases. -->
1. Confirm the workflow run completes and posts both the "Summary Changes" comment and the structural-checks review comment.
2. Check the Structural Checks table — all three checks (`ANALYSIS.md` not added, naming, `README.md` exists) should show ✅ Pass.
3. Check the Actions log for `extractConstraints` — confirm the constraints text (`1 <= s.length <= 1000`, `1 <= numRows <= 1000`) is correctly extracted from the README and appears in the `Problem Constraints` section passed to the model (no `core.warning` about a parse failure).
4. Check the Actions log for any `Inline comment on ... anchored to context line (not a pure addition).` messages — none should appear, since this is a brand-new file and every diff line is an addition.
5. Confirm the AI review's `time_complexity` and `space_memory` checks read as `pass` given the O(n)/O(n) implementation against the `n <= 1000` constraint — a reasonable baseline to sanity-check the rubric isn't misfiring on a correct solution.
6. Comment `@mirabile what's the time complexity here?` on the PR to exercise the `issue_comment` / question-answering path and confirm it classifies as `problem` and responds with the correct complexity.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Folder named correctly: `{number}-{problem-slug}` e.g. `1-two-sum`
- [x] Folder placed inside the correct language directory e.g. `cpp/1-two-sum/`
- [x] Solution file named correctly: `{slug}.{ext}` e.g. `two-sum.cpp`
- [x] `README.md` exists in the problem folder with the LeetCode HTML description
- [x] No `ANALYSIS.md` manually added (auto-generated by CI pipeline)
- [x] No debug print statements left in the solution
- [x] PR description is filled in with Summary, Related Issue, and How to Validate
