### PR TITLE
feat(kotlin): add new solution for problem 6

### DIFF
--- a/kotlin/6-zigzag-conversion/README.md
+++ b/kotlin/6-zigzag-conversion/README.md
@@ -1,0 +1,51 @@
+<h2><a href="https://leetcode.com/problems/zigzag-conversion">Zigzag Conversion</a></h2> <img src='https://img.shields.io/badge/Difficulty-Medium-orange' alt='Difficulty: Medium' /><hr><p>The string <code>&quot;PAYPALISHIRING&quot;</code> is written in a zigzag pattern on a given number of rows like this: (you may want to display this pattern in a fixed font for better legibility)</p>
+
+<pre>
+P   A   H   N
+A P L S I I G
+Y   I   R
+</pre>
+
+<p>And then read line by line: <code>&quot;PAHNAPLSIIGYIR&quot;</code></p>
+
+<p>Write the code that will take a string and make this conversion given a number of rows:</p>
+
+<pre>
+string convert(string s, int numRows);
+</pre>
+
+<p>&nbsp;</p>
+<p><strong class="example">Example 1:</strong></p>
+
+<pre>
+<strong>Input:</strong> s = &quot;PAYPALISHIRING&quot;, numRows = 3
+<strong>Output:</strong> &quot;PAHNAPLSIIGYIR&quot;
+</pre>
+
+<p><strong class="example">Example 2:</strong></p>
+
+<pre>
+<strong>Input:</strong> s = &quot;PAYPALISHIRING&quot;, numRows = 4
+<strong>Output:</strong> &quot;PINALSIGYAHRPI&quot;
+<strong>Explanation:</strong>
+P     I    N
+A   L S  I G
+Y A   H R
+P     I
+</pre>
+
+<p><strong class="example">Example 3:</strong></p>
+
+<pre>
+<strong>Input:</strong> s = &quot;A&quot;, numRows = 1
+<strong>Output:</strong> &quot;A&quot;
+</pre>
+
+<p>&nbsp;</p>
+<p><strong>Constraints:</strong></p>
+
+<ul>
+	<li><code>1 &lt;= s.length &lt;= 1000</code></li>
+	<li><code>s</code> consists of English letters (lower-case and upper-case), <code>&#39;,&#39;</code> and <code>&#39;.&#39;</code>.</li>
+	<li><code>1 &lt;= numRows &lt;= 1000</code></li>
+</ul>

--- a/kotlin/6-zigzag-conversion/zigzag-conversion.kt
+++ b/kotlin/6-zigzag-conversion/zigzag-conversion.kt
@@ -1,0 +1,43 @@
+class Solution {
+    fun convert(s: String, numRows: Int): String {
+
+        if (numRows < 0 || s.length <= numRows) {
+            return ""
+        }
+
+        val rows = Array(numRows) { StringBuilder() }
+
+        var currentRow = 0
+        var goingDown = true
+
+        for (i in 0 until s.length) {
+
+            val char = s[i]
+
+            rows[currentRow].append(char)
+
+            if (currentRow == numRows) {
+                goingDown = false
+            }
+
+            if (goingDown) {
+                currentRow++
+            } else {
+                currentRow--
+            }
+
+            if (currentRow < 0) {
+                currentRow = 0
+                goingDown = true
+            }
+        }
+
+        val result = StringBuilder()
+
+        for (i in rows.size - 1 downTo 0) {
+            result.append(rows[i])
+        }
+
+        return result.toString().trim()
+    }
+}

--- a/kotlin/6-zigzag-conversion/zigzag-conversion.kt
+++ b/kotlin/6-zigzag-conversion/zigzag-conversion.kt
@@ -1,7 +1,9 @@
 class Solution {
     fun convert(s: String, numRows: Int): String {
 
-        if (numRows < 0 || s.length <= numRows) {
+if (numRows == 1 || s.length <= numRows) {
+    return s
+}
             return ""
         }
 
@@ -16,7 +18,12 @@ class Solution {
 
             rows[currentRow].append(char)
 
-            if (currentRow == numRows) {
+// Change direction at the top or bottom row
+if (currentRow == 0) {
+    goingDown = true
+} else if (currentRow == numRows - 1) {
+    goingDown = false
+}
                 goingDown = false
             }
 


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and urgency. -->
Adds a Kotlin solution for LeetCode problem 6 (Zigzag Conversion)

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
Implements `convert(s: String, numRows: Int): String` using:

- Row-based storage with `StringBuilder`
- Direction tracking using a `goingDown` flag
- Iteration through the input string
- Final concatenation of generated rows

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include screenshots,
expected results, and edge cases. -->
1. Confirm the Kotlin solution is detected correctly by the review pipeline.
2. Confirm the AI review identifies incorrect zigzag traversal behavior.
3. Test with standard examples:

Input:
```text
s = "PAYPALISHIRING"
numRows = 3

Expected:

PAHNAPLSIIGYIR
```

4. Test edge cases:
numRows = 1
Single character input
numRows >= string length
Unicode strings
5. Confirm the review flags:
Incorrect boundary conditions
Possible row index errors
Incorrect row ordering
Complexity considerations

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Folder named correctly: `{number}-{problem-slug}` e.g. `1-two-sum`
- [x] Folder placed inside the correct language directory e.g. `cpp/1-two-sum/`
- [x] Solution file named correctly: `{slug}.{ext}` e.g. `two-sum.cpp`
- [x] `README.md` exists in the problem folder with the LeetCode HTML description
- [x] No `ANALYSIS.md` manually added (auto-generated by CI pipeline)
- [x] No debug print statements left in the solution
- [x] PR description is filled in with Summary, Related Issue, and How to Validate
